### PR TITLE
Fix poll active status handling

### DIFF
--- a/backend/models/poll.js
+++ b/backend/models/poll.js
@@ -67,6 +67,7 @@ class Poll {
       taskDescription: this.taskDescription,
       options: this.options,
       displayStyle: this.displayStyle,
+      isActive: this.isActive,
     };
   }
 }

--- a/frontend/js/votingInterface.js
+++ b/frontend/js/votingInterface.js
@@ -42,8 +42,8 @@ class VotingInterface {
         this.updateChartData(results);
       });
 
-      // If the poll is active, allow voting
-      if (!this.pollData.isEnded) {
+      // Enable or disable voting based on poll status
+      if (this.pollData.isActive) {
         this.enableVoting();
       } else {
         this.disableVoting();


### PR DESCRIPTION
## Summary
- expose `isActive` when returning poll details
- use `isActive` on the frontend to decide if voting should be enabled

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68479cb48a7c832bb6452da76b504f55