### PR TITLE
Update Windows helper docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ node_modules/
 # Editor directories and files
 .vscode/
 
-# Executables
-voting-app.exe/
+# Executable binaries
+*.exe

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To set up the project locally, follow these steps:
     ```
 
 4. **Open the frontend in a browser:**
-    Simply open the `index.html` file located in the `frontend` directory.
+    Navigate to `http://localhost:3000/` after starting the backend.
 
 ## Usage
 
@@ -116,24 +116,22 @@ Note: For production, use a certificate from a trusted CA to avoid browser secur
 
 ## Text Capture Integration (Windows)
 
-The repository includes a lightweight Windows helper located in `windows_capture/ClaptureApp.cpp`.
-When compiled, it allows you to select text anywhere on screen and quickly create a poll from it.
+MiniPoller includes a small Windows utility called `OverlayPoller.exe` located
+in `windows_capture/OverlayPoller.cpp`.
 
 ### Building the Helper
 
-1. Open the `ClaptureApp.cpp` file in Visual Studio 2022.
+1. Open `OverlayPoller.cpp` in Visual Studio 2022.
 2. Build it as a **Win32 Console Application**.
-3. The resulting `ClaptureApp.exe` should be placed in `windows_capture/`.
+3. Copy the resulting `OverlayPoller.exe` into the `windows_capture` directory.
 
 ### Using
 
-When you start the backend server on Windows (`npm start` in the `backend` directory),
-the helper is launched automatically. Drag to select text and release; a small menu
-appears near the cursor. Choose **Create Poll** to open your browser with the
-poll question pre-filled. The backend monitors the helper process and will
-restart it if it exits unexpectedly. When MiniPoller shuts down (for example by
-pressing `Ctrl+C`), the helper is terminated automatically to avoid leaving
-orphaned processes running.
+1. Start the backend server (`npm start` inside the `backend` folder`).
+2. `OverlayPoller.exe` launches automatically.
+3. Select text anywhere on screen. When you release the mouse, an overlay
+   window appears allowing you to submit a poll.
+4. Closing the server stops the helper process automatically.
 
 ## Contributing
 Contributions are welcome! Please open an issue or submit a pull request for any improvements or bug fixes.

--- a/backend/server.js
+++ b/backend/server.js
@@ -23,7 +23,7 @@ let shuttingDown = false;
  * globally so it can be restarted or terminated when the server exits.
  */
 function startCaptureProcess() {
-  const captureExe = path.join(__dirname, "../windows_capture/ClaptureApp.exe");
+  const captureExe = path.join(__dirname, "../windows_capture/OverlayPoller.exe");
   if (!fs.existsSync(captureExe)) {
     console.log(`Capture executable not found at ${captureExe}`);
     return;


### PR DESCRIPTION
## Summary
- ignore Windows binaries
- open `http://localhost:3000/` for the frontend
- document `OverlayPoller.exe` helper and workflow
- use new helper executable in the backend

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d766209c0832b85a3fbbaa6d3d169