### PR TITLE
Clean up Windows helpers

### DIFF
--- a/windows_capture/ClaptureApp.cpp
+++ b/windows_capture/ClaptureApp.cpp
@@ -10,15 +10,6 @@
 #include <locale>
 #include <sstream>
 
-// Structure to hold the captured data (text only)
-struct CaptureData {
-    std::wstring text;   // Captured text
-};
-
-CaptureData g_captureData = { L"" };
-bool g_captureAvailable = false;
-CRITICAL_SECTION g_captureLock;
-
 // Global variables for mouse drag state
 bool g_isDragging = false;
 POINT g_startPoint = { 0, 0 };
@@ -61,8 +52,6 @@ int main()
     // Set locale for Unicode output.
     std::setlocale(LC_ALL, "");
 
-    // Initialize critical section for thread safety.
-    InitializeCriticalSection(&g_captureLock);
 
     // Create a thread for the mouse hook.
     HANDLE hThread = CreateThread(NULL, 0, MouseHookThread, NULL, 0, NULL);
@@ -86,7 +75,6 @@ int main()
     WaitForSingleObject(hThread, INFINITE);
     CloseHandle(hThread);
 
-    DeleteCriticalSection(&g_captureLock);
     return 0;
 }
 
@@ -174,11 +162,6 @@ void PerformCapture()
     if (capturedText.empty())
         return;
 
-    // Store the captured text.
-    EnterCriticalSection(&g_captureLock);
-    g_captureData.text = capturedText;
-    g_captureAvailable = true;
-    LeaveCriticalSection(&g_captureLock);
 
     // Show a simple context menu at the cursor position.
     HMENU hMenu = CreatePopupMenu();

--- a/windows_capture/OverlayPoller.cpp
+++ b/windows_capture/OverlayPoller.cpp
@@ -8,14 +8,6 @@
 #include <algorithm>
 #pragma comment(lib, "winhttp.lib")
 
-struct CaptureData {
-    std::wstring text;
-};
-
-CaptureData g_captureData{L""};
-bool g_captureAvailable = false;
-CRITICAL_SECTION g_captureLock;
-
 bool g_isDragging = false;
 POINT g_startPoint{0,0};
 POINT g_endPoint{0,0};
@@ -56,7 +48,6 @@ DWORD WINAPI MouseHookThread(LPVOID lpParam)
 int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)
 {
     std::setlocale(LC_ALL, "");
-    InitializeCriticalSection(&g_captureLock);
     HANDLE hThread = CreateThread(NULL,0,MouseHookThread,NULL,0,NULL);
     MSG msg;
     while(GetMessage(&msg,NULL,0,0)) {
@@ -64,7 +55,6 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)
     }
     PostThreadMessage(GetThreadId(hThread), WM_QUIT,0,0);
     WaitForSingleObject(hThread,INFINITE);
-    DeleteCriticalSection(&g_captureLock);
     return 0;
 }
 
@@ -106,10 +96,6 @@ void PerformCapture()
     std::wstring captured = GetClipboardText();
     ShowWindow(hConsole, SW_SHOW);
     if(captured.empty()) return;
-    EnterCriticalSection(&g_captureLock);
-    g_captureData.text=captured;
-    g_captureAvailable=true;
-    LeaveCriticalSection(&g_captureLock);
     ShowOverlayWindow(captured);
 }
 
@@ -184,14 +170,6 @@ LRESULT CALLBACK OverlayWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
     return DefWindowProc(hwnd,msg,wParam,lParam);
 }
 
-std::wstring ToUTF8(const std::wstring &w)
-{
-    if(w.empty()) return std::string().c_str();
-    int size=WideCharToMultiByte(CP_UTF8,0,w.c_str(),-1,NULL,0,NULL,NULL);
-    std::string s(size-1,0);
-    WideCharToMultiByte(CP_UTF8,0,w.c_str(),-1,s.data(),size,NULL,NULL);
-    return std::wstring(s.begin(), s.end());
-}
 
 bool SubmitPoll(const std::wstring &q, const std::vector<std::wstring> &opts, std::wstring &outUrl)
 {


### PR DESCRIPTION
## Summary
- remove unused ToUTF8 helper
- drop unused capture state and critical sections

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d76665780832bb6a1836669e8c774